### PR TITLE
Fix Reading Literal Blocks

### DIFF
--- a/inflate-bit32.lua
+++ b/inflate-bit32.lua
@@ -21,7 +21,7 @@ function inflate.bitstream_init(file)
     file = file,  -- the open file handle
     buf = nil,    -- character buffer
     len = nil,    -- length of character buffer
-    pos = 1,      -- position in char buffer
+    pos = 1,      -- position in char buffer, next to be read
     b = 0,        -- bit buffer
     n = 0,        -- number of bits in buffer
   }
@@ -44,7 +44,7 @@ function inflate.bitstream_init(file)
   -- peek a number of n bits from stream
   function bs:peekb(n)
     while self.n < n do
-      self.b = self.b + bit.lshift(self.buf:byte(self.pos),self.n)
+      self.b = self.b + bit.lshift(self:next_byte(),self.n)
       self.n = self.n + 8
     end
     return bit.band(self.b,bit.lshift(1,n)-1)

--- a/inflate-bit32.lua
+++ b/inflate-bit32.lua
@@ -38,7 +38,7 @@ function inflate.bitstream_init(file)
       self.pos = 1
     end
     local pos = self.pos
-    self.pos = self.pos + 1
+    self.pos = pos + 1
     return self.buf:byte(pos)
   end
   -- peek a number of n bits from stream

--- a/inflate-bwo.lua
+++ b/inflate-bwo.lua
@@ -36,7 +36,7 @@ function inflate.bitstream_init(file)
       self.pos = 1
     end
     local pos = self.pos
-    self.pos = self.pos + 1
+    self.pos = pos + 1
     return self.buf:byte(pos)
   end
   -- peek a number of n bits from stream


### PR DESCRIPTION
This PR fixes the decoding of so called stored sections (aka literal blocks) which is done in the `block_uncompressed` function. 

Previously, the `block_uncompressed` function directly accessed the `buf` field trying to read as many bytes as that section specified, which may be as many as 2^16 bytes (i.e. 64 KiB). However, the `buf` field holds at most 4 KiB, as read by the `peekb` function, causing out-of-bounds accesses, which in turn cause the following error:

```text
$ dd if=/dev/random of=/dev/stdout bs=1 count=4096 | gzip -f > foo.gz
$ lua
> require("zzlib").gunzipf("foo.gz")
./inflate-bwo.lua:227: wrong number of arguments to 'insert'
stack traceback:
	[C]: in function 'table.insert'
	./inflate-bwo.lua:227: in upvalue 'block_uncompressed'
	./inflate-bwo.lua:240: in function 'inflate-bwo.main'
	./zzlib.lua:82: in function <./zzlib.lua:56>
	(...tail calls...)
	[C]: in ?
```

Instead, this PR extracts the refilling of the `buf` field into a new `next_byte` function, which is then used by both the `peekb` and `block_uncompressed` function. Thus fixing the issue.

_Notice, this issue has been noted with Lua 5.3 using the bwo implementation, specifically. Tho, it appears that the same algorithm is used in the bit32 implementation so it has been altered accordingly as well, tho the bit32 implementation has not been tested!_